### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/api/RTProxyImpl.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/api/RTProxyImpl.java
@@ -108,7 +108,7 @@ public class RTProxyImpl implements RTProxy {
     }
 
     private Activity getActivity() {
-        if (mActivity == null && mActivity.get() == null) {
+        if (mActivity == null || mActivity.get() == null) {
             throw new IncorrectInitializationException(
                     "The RTApi was't initialized correctly or the Activity was released by Android (SoftReference)");
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.
