### PR TITLE
[squid:S1149] Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/ElementType.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/ElementType.java
@@ -252,7 +252,7 @@ public class ElementType {
             return value;
         boolean space = false;
         int len = value.length();
-        StringBuffer b = new StringBuffer(len);
+        StringBuilder b = new StringBuilder(len);
         for (int i = 0; i < len; i++) {
             char v = value.charAt(i);
             if (v == ' ') {

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
@@ -930,7 +930,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
         if (src == null)
             return null;
         int len = src.length();
-        StringBuffer dst = new StringBuffer(len);
+        StringBuilder dst = new StringBuilder(len);
         boolean suppressSpace = true;
         for (int i = 0; i < len; i++) {
             char ch = src.charAt(i);
@@ -1090,7 +1090,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
     // This no longer lowercases the result: we depend on Schema to
     // canonicalize case.
     private String makeName(char[] buff, int offset, int length) {
-        StringBuffer dst = new StringBuffer(length + 2);
+        StringBuilder dst = new StringBuilder(length + 2);
         boolean seenColon = false;
         boolean start = true;
         // String src = new String(buff, offset, length); // DEBUG


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.
Ayman Abdelghany.
