### PR TITLE
[squid:S1155] Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/FilenameUtils.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/FilenameUtils.java
@@ -1291,7 +1291,7 @@ public class FilenameUtils {
         
         // loop around a backtrack stack, to handle complex * matching
         do {
-            if (backtrack.size() > 0) {
+            if (!backtrack.isEmpty()) {
                 int[] array = backtrack.pop();
                 wcsIdx = array[0];
                 textIdx = array[1];
@@ -1350,7 +1350,7 @@ public class FilenameUtils {
                 return true;
             }
             
-        } while (backtrack.size() > 0);
+        } while (!backtrack.isEmpty());
   
         return false;
     }

--- a/app/src/main/java/com/momana/bhromo/memoir/adapter/NotesCalendarAdapter.java
+++ b/app/src/main/java/com/momana/bhromo/memoir/adapter/NotesCalendarAdapter.java
@@ -76,7 +76,7 @@ public class NotesCalendarAdapter extends RecyclerView.Adapter<RecyclerView.View
     public void refreshNotes() {
         notes = NotesDatabase.getInstance(context).getNotesOfDate(currentDate);
         notifyDataSetChanged();
-        if (notes.size() == 0) {
+        if (notes.isEmpty()) {
             SimpleDateFormat fmt = new SimpleDateFormat("dd MMM yyyy");
             Toast.makeText(context, "No notes found for " + fmt.format(currentDate), Toast.LENGTH_SHORT).show();
         }

--- a/app/src/main/java/com/momana/bhromo/memoir/fragment/AtlasFragment.java
+++ b/app/src/main/java/com/momana/bhromo/memoir/fragment/AtlasFragment.java
@@ -94,7 +94,7 @@ public class AtlasFragment extends Fragment implements OnMapReadyCallback, OnMar
             }
         }
 
-        if (noteList.size() > 0) {
+        if (!noteList.isEmpty()) {
             // Zoom to markers
             mMap.setOnCameraChangeListener(new GoogleMap.OnCameraChangeListener() {
                 @Override

--- a/app/src/main/java/com/momana/bhromo/memoir/fragment/NotesFragment.java
+++ b/app/src/main/java/com/momana/bhromo/memoir/fragment/NotesFragment.java
@@ -60,7 +60,7 @@ public class NotesFragment extends Fragment implements NoteGridAdapter.OnItemCli
 
     // Helper Method
     public void refreshLayout() {
-        if (adapter.notes.size() == 0) {
+        if (adapter.notes.isEmpty()) {
             noteGrid.setVisibility(View.GONE);
             placeholderText.setVisibility(View.VISIBLE);
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Ayman Abdelghany.
