### PR TITLE
[squid:S1319] Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/ConverterHtmlToSpanned.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/ConverterHtmlToSpanned.java
@@ -67,6 +67,7 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.regex.Matcher;
@@ -903,7 +904,7 @@ public class ConverterHtmlToSpanned implements ContentHandler {
 
     // ****************************************** Color Methods *******************************************
 
-    private static HashMap<String, Integer> COLORS = new HashMap<String, Integer>();
+    private static Map<String, Integer> COLORS = new HashMap<String, Integer>();
 
     static {
         COLORS.put("aqua", 0x00FFFF);

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Schema.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Schema.java
@@ -19,6 +19,7 @@ package com.onegravity.rteditor.converter.tagsoup;
 import android.annotation.SuppressLint;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Abstract class representing a TSSL schema. Actual TSSL schemas are compiled
@@ -35,8 +36,8 @@ public abstract class Schema {
     public static final int F_CDATA = 2;
     public static final int F_NOFORCE = 4;
 
-    private HashMap<String, Integer> theEntities = new HashMap<String, Integer>();
-    private HashMap<String, ElementType> theElementTypes = new HashMap<String, ElementType>();
+    private Map<String, Integer> theEntities = new HashMap<String, Integer>();
+    private Map<String, ElementType> theElementTypes = new HashMap<String, ElementType>();
 
     private String theURI = "";
     private String thePrefix = "";

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/util/LookupTranslator.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/util/LookupTranslator.java
@@ -20,6 +20,7 @@ package com.onegravity.rteditor.converter.tagsoup.util;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Translates a value using a lookup table.
@@ -29,7 +30,7 @@ import java.util.HashMap;
  */
 public class LookupTranslator extends CharSequenceTranslator {
 
-    private final HashMap<String, CharSequence> lookupMap;
+    private final Map<String, CharSequence> lookupMap;
     private final int shortest;
     private final int longest;
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/Effects.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/Effects.java
@@ -31,6 +31,7 @@ import com.onegravity.rteditor.spans.TypefaceSpan;
 import com.onegravity.rteditor.spans.UnderlineSpan;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class Effects {
     // character effects
@@ -55,7 +56,7 @@ public class Effects {
     /*
      * ALL_EFFECTS is a list of all defined effects, for simpler iteration over all effects.
      */
-    public static final ArrayList<Effect> ALL_EFFECTS = new ArrayList<Effect>();
+    public static final List<Effect> ALL_EFFECTS = new ArrayList<Effect>();
 
     static {
         // character effects
@@ -81,7 +82,7 @@ public class Effects {
     /*
      * FORMATTING_EFFECTS is a list of all effects which will be removed when the formatting is removed from the text.
      */
-    public static final ArrayList<Effect> FORMATTING_EFFECTS = new ArrayList<Effect>();
+    public static final List<Effect> FORMATTING_EFFECTS = new ArrayList<Effect>();
 
     static {
         // character effects

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/ParagraphSpanProcessor.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/ParagraphSpanProcessor.java
@@ -44,7 +44,7 @@ class ParagraphSpanProcessor<V extends Object> {
         }
     }
 
-    final private ArrayList<ParagraphSpan<V>> mParagraphSpans = new ArrayList<ParagraphSpan<V>>();
+    final private List<ParagraphSpan<V>> mParagraphSpans = new ArrayList<ParagraphSpan<V>>();
 
     void clear() {
         mParagraphSpans.clear();

--- a/app/src/main/java/com/momana/bhromo/memoir/fragment/AtlasFragment.java
+++ b/app/src/main/java/com/momana/bhromo/memoir/fragment/AtlasFragment.java
@@ -32,6 +32,7 @@ import com.momana.bhromo.memoir.database.NotesDatabase;
 import com.momana.bhromo.memoir.model.Note;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class AtlasFragment extends Fragment implements OnMapReadyCallback, OnMarkerClickListener {
 
@@ -85,7 +86,7 @@ public class AtlasFragment extends Fragment implements OnMapReadyCallback, OnMar
 
         // Find notes with location
         noteList = new ArrayList<>();
-        ArrayList<Note> notes = NotesDatabase.getInstance(getContext()).getNotes();
+        List<Note> notes = NotesDatabase.getInstance(getContext()).getNotes();
         for (int i = 0; i < notes.size(); i++) {
             if (notes.get(i).location.placeName.length() != 0) {
                 noteList.add(notes.get(i));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319

Please let me know if you have any questions.
Ayman Abdelghany.
