### PR TITLE
[squid:S2864] "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLWriter.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLWriter.java
@@ -627,9 +627,9 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
     private boolean ignoreElement(String uri, String localName, String qName, Attributes atts) {
         Map<String, String> tagAttrs = mTags2Ignore.get(qName.toLowerCase(Locale.US));
         if (tagAttrs != null) {
-            for (String attrKey : tagAttrs.keySet()) {
-                for (String attrValue : tagAttrs.get(attrKey).split("#")) {
-                    String value = atts.getValue(attrKey);
+            for (Map.Entry<String, String> entry : tagAttrs.entrySet()) {
+                for (String attrValue : entry.getValue().split("#")) {
+                    String value = atts.getValue(entry.getKey());
                     if (!isNullOrEmpty(value) && attrValue.equalsIgnoreCase(value)) {
                         mIgnoredTags.push(qName);
                         return true;

--- a/RTEditor/src/main/java/com/onegravity/rteditor/fonts/FontManager.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/fonts/FontManager.java
@@ -96,12 +96,12 @@ public class FontManager {
          */
         Map<String, String> assetFonts = getAssetFonts(context);
         AssetManager assets = context.getResources().getAssets();
-        for (String fontName : assetFonts.keySet()) {
-            String filePath = assetFonts.get(fontName);
-            if (!ALL_FONTS.contains(fontName)) {
+        for (Map.Entry<String, String> entry : assetFonts.entrySet()) {
+            String filePath = entry.getValue();
+            if (!ALL_FONTS.contains(entry.getKey())) {
                 try {
                     Typeface typeface = Typeface.createFromAsset(assets, filePath);
-                    ALL_FONTS.add(new RTTypeface(fontName, typeface));
+                    ALL_FONTS.add(new RTTypeface(entry.getKey(), typeface));
                 }
                 catch (Exception e) {
                     // this can happen if we don't have access to the font or it's not a font or...


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.
Ayman Abdelghany.
