### PR TITLE
[squid:S2786] Nested "enum"s should not be declared static

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/util/NumericEntityUnescaper.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/util/NumericEntityUnescaper.java
@@ -33,7 +33,7 @@ import java.util.EnumSet;
  */
 public class NumericEntityUnescaper extends CharSequenceTranslator {
 
-    public static enum OPTION {semiColonRequired, semiColonOptional, errorIfNoSemiColon}
+    public enum OPTION {semiColonRequired, semiColonOptional, errorIfNoSemiColon}
 
     private final EnumSet<OPTION> options;
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/BitmapManager.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/BitmapManager.java
@@ -39,7 +39,7 @@ import android.graphics.BitmapFactory;
  */
 public class BitmapManager {
 
-    private static enum State {
+    private enum State {
         CANCEL, ALLOW
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2786 - “Nested "enum"s should not be declared static”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2786

Please let me know if you have any questions.
Ayman Abdelghany.
