### PR TITLE
[squid:S1161] "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/ClonedSpannableString.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/ClonedSpannableString.java
@@ -116,6 +116,7 @@ public class ClonedSpannableString extends SpannableString {
         }
     }
 
+    @Override
     public int getSpanStart(Object what) {
         int count = mSpanCount;
         Object[] spans = mSpans;
@@ -130,6 +131,7 @@ public class ClonedSpannableString extends SpannableString {
         return -1;
     }
 
+    @Override
     public int getSpanEnd(Object what) {
         int count = mSpanCount;
         Object[] spans = mSpans;
@@ -144,6 +146,7 @@ public class ClonedSpannableString extends SpannableString {
         return -1;
     }
 
+    @Override
     public int getSpanFlags(Object what) {
         int count = mSpanCount;
         Object[] spans = mSpans;
@@ -158,6 +161,7 @@ public class ClonedSpannableString extends SpannableString {
         return 0;
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public <T> T[] getSpans(int queryStart, int queryEnd, Class<T> kind) {
         int count = 0;
@@ -239,6 +243,7 @@ public class ClonedSpannableString extends SpannableString {
         return (T[]) nret;
     }
 
+    @Override
     @SuppressWarnings("rawtypes")
     public int nextSpanTransition(int start, int limit, Class kind) {
         int count = mSpanCount;

--- a/RTEditor/src/main/java/com/onegravity/rteditor/RTEditText.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/RTEditText.java
@@ -566,9 +566,11 @@ public class RTEditText extends EditText implements TextWatcher, SpanWatcher, Li
 
         public static final Parcelable.Creator<SavedState> CREATOR =
                 new Parcelable.Creator<SavedState>() {
+                    @Override
                     public SavedState createFromParcel(Parcel in) {
                         return new SavedState(in);
                     }
+                    @Override
                     public SavedState[] newArray(int size) {
                         return new SavedState[size];
                     }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/AttributesImpl.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/AttributesImpl.java
@@ -108,6 +108,7 @@ public class AttributesImpl implements Attributes {
      * @return The number of attributes in the list.
      * @see org.xml.sax.Attributes#getLength
      */
+    @Override
     public int getLength() {
         return length;
     }
@@ -120,6 +121,7 @@ public class AttributesImpl implements Attributes {
      * if the index is out of range.
      * @see org.xml.sax.Attributes#getURI
      */
+    @Override
     public String getURI(int index) {
         if (index >= 0 && index < length) {
             return data[index * 5];
@@ -136,6 +138,7 @@ public class AttributesImpl implements Attributes {
      * available, or null if the index if out of range.
      * @see org.xml.sax.Attributes#getLocalName
      */
+    @Override
     public String getLocalName(int index) {
         if (index >= 0 && index < length) {
             return data[index * 5 + 1];
@@ -152,6 +155,7 @@ public class AttributesImpl implements Attributes {
      * available, or null if the index is out of bounds.
      * @see org.xml.sax.Attributes#getQName
      */
+    @Override
     public String getQName(int index) {
         if (index >= 0 && index < length) {
             return data[index * 5 + 2];
@@ -168,6 +172,7 @@ public class AttributesImpl implements Attributes {
      * the index is out of bounds.
      * @see org.xml.sax.Attributes#getType(int)
      */
+    @Override
     public String getType(int index) {
         if (index >= 0 && index < length) {
             return data[index * 5 + 3];
@@ -183,6 +188,7 @@ public class AttributesImpl implements Attributes {
      * @return The attribute's value or null if the index is out of bounds.
      * @see org.xml.sax.Attributes#getValue(int)
      */
+    @Override
     public String getValue(int index) {
         if (index >= 0 && index < length) {
             return data[index * 5 + 4];
@@ -206,6 +212,7 @@ public class AttributesImpl implements Attributes {
      * @return The attribute's index, or -1 if none matches.
      * @see org.xml.sax.Attributes#getIndex(java.lang.String, java.lang.String)
      */
+    @Override
     public int getIndex(String uri, String localName) {
         int max = length * 5;
         for (int i = 0; i < max; i += 5) {
@@ -223,6 +230,7 @@ public class AttributesImpl implements Attributes {
      * @return The attribute's index, or -1 if none matches.
      * @see org.xml.sax.Attributes#getIndex(java.lang.String)
      */
+    @Override
     public int getIndex(String qName) {
         int max = length * 5;
         for (int i = 0; i < max; i += 5) {
@@ -242,6 +250,7 @@ public class AttributesImpl implements Attributes {
      * @return The attribute's type, or null if there is no matching attribute.
      * @see org.xml.sax.Attributes#getType(java.lang.String, java.lang.String)
      */
+    @Override
     public String getType(String uri, String localName) {
         int max = length * 5;
         for (int i = 0; i < max; i += 5) {
@@ -259,6 +268,7 @@ public class AttributesImpl implements Attributes {
      * @return The attribute's type, or null if there is no matching attribute.
      * @see org.xml.sax.Attributes#getType(java.lang.String)
      */
+    @Override
     public String getType(String qName) {
         int max = length * 5;
         for (int i = 0; i < max; i += 5) {
@@ -278,6 +288,7 @@ public class AttributesImpl implements Attributes {
      * @return The attribute's value, or null if there is no matching attribute.
      * @see org.xml.sax.Attributes#getValue(java.lang.String, java.lang.String)
      */
+    @Override
     public String getValue(String uri, String localName) {
         int max = length * 5;
         for (int i = 0; i < max; i += 5) {
@@ -295,6 +306,7 @@ public class AttributesImpl implements Attributes {
      * @return The attribute's value, or null if there is no matching attribute.
      * @see org.xml.sax.Attributes#getValue(java.lang.String)
      */
+    @Override
     public String getValue(String qName) {
         int max = length * 5;
         for (int i = 0; i < max; i += 5) {

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLScanner.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLScanner.java
@@ -199,18 +199,22 @@ public class HTMLScanner implements Scanner, Locator {
 
     // Locator implementation
 
+    @Override
     public int getLineNumber() {
         return theLastLine;
     }
 
+    @Override
     public int getColumnNumber() {
         return theLastColumn;
     }
 
+    @Override
     public String getPublicId() {
         return thePublicid;
     }
 
+    @Override
     public String getSystemId() {
         return theSystemid;
     }
@@ -224,6 +228,7 @@ public class HTMLScanner implements Scanner, Locator {
      * @param publicid Public id
      */
 
+    @Override
     public void resetDocumentLocator(String publicid, String systemid) {
         thePublicid = publicid;
         theSystemid = systemid;
@@ -236,6 +241,7 @@ public class HTMLScanner implements Scanner, Locator {
      * @param r0 Reader that provides characters
      * @param h  ScanHandler that accepts lexical events.
      */
+    @Override
     public void scan(Reader r0, ScanHandler h) throws IOException, SAXException {
         theState = S_PCDATA;
         PushbackReader r;
@@ -530,6 +536,7 @@ public class HTMLScanner implements Scanner, Locator {
      * CDATA content (no markup is recognized except the end of element.
      */
 
+    @Override
     public void startCDATA() {
         theNextState = S_CDATA;
     }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLWriter.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLWriter.java
@@ -529,6 +529,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
      *                                  handler further down the filter chain raises an exception.
      * @see org.xml.sax.ContentHandler#startDocument
      */
+    @Override
     public void startDocument() throws SAXException {
         writeText4Links();
         reset();
@@ -567,6 +568,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
      *                                  further down the filter chain raises an exception.
      * @see org.xml.sax.ContentHandler#endDocument
      */
+    @Override
     public void endDocument() throws SAXException {
         writeText4Links();
         write('\n');
@@ -1092,6 +1094,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
     private static final String[] LINK_SCHEMAS = new String[]{"http://", "https://", "rtsp://"};
 
     private static final MatchFilter URL_MATCH_FILTER = new MatchFilter() {
+        @Override
         public final boolean acceptMatch(CharSequence s, int start, int end) {
             return start == 0 || s.charAt(start - 1) != '@';
         }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
@@ -453,6 +453,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
         if (theScanner == null) theScanner = new HTMLScanner();
         if (theAutoDetector == null) {
             theAutoDetector = new AutoDetector() {
+                @Override
                 public Reader autoDetectingReader(InputStream i) {
                     return new InputStreamReader(i);
                 }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/CharacterEffect.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/CharacterEffect.java
@@ -45,6 +45,7 @@ abstract class CharacterEffect<V, C extends RTSpan<V>> extends Effect<V, C> {
      * @param editor The editor to apply the effect to (current selection)
      * @param value  The value to apply (depends on the Effect)
      */
+    @Override
     public void applyToSelection(RTEditText editor, V value) {
         Selection selection = getSelection(editor);
         // SPAN_INCLUSIVE_INCLUSIVE is default for empty spans

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/IndentationEffect.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/IndentationEffect.java
@@ -39,6 +39,7 @@ public class IndentationEffect extends ParagraphEffect<Integer, IndentationSpan>
 
     private ParagraphSpanProcessor<Integer> mSpans2Process = new ParagraphSpanProcessor();
 
+    @Override
     public void applyToSelection(RTEditText editor, Selection selectedParagraphs, Integer increment) {
         final Spannable str = editor.getText();
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/fonts/FontManager.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/fonts/FontManager.java
@@ -50,6 +50,7 @@ public class FontManager {
         /**
          * @return The RTTypeface with the specified name or false if no such RTTypeface exists.
          */
+        @Override
         RTTypeface get(String fontName) {
             for (RTTypeface typeface : this) {
                 if (typeface.getName().equals(fontName)) {
@@ -62,6 +63,7 @@ public class FontManager {
         /**
          * @return True if the collections contains an RTTypeface with the specified name, false otherwise.
          */
+        @Override
         boolean contains(String fontName) {
             return get(fontName) != null;
         }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/fonts/TTFInputStream.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/fonts/TTFInputStream.java
@@ -27,5 +27,6 @@ public interface TTFInputStream extends Closeable {
     public int read (byte[] b) throws IOException;
     public int read () throws IOException;
     public void seek(long pos) throws IOException;
+    @Override
     public void close() throws IOException;
 }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/MonitoredActivity.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/MonitoredActivity.java
@@ -50,21 +50,27 @@ public class MonitoredActivity extends AppCompatActivity {
     }
 
     public static class LifeCycleAdapter implements LifeCycleListener {
+        @Override
         public void onActivityCreated(Activity activity) {
         }
 
+        @Override
         public void onActivityDestroyed(Activity activity) {
         }
 
+        @Override
         public void onActivityPaused(Activity activity) {
         }
 
+        @Override
         public void onActivityResumed(Activity activity) {
         }
 
+        @Override
         public void onActivityStarted(Activity activity) {
         }
 
+        @Override
         public void onActivityStopped(Activity activity) {
         }
     }
@@ -187,6 +193,7 @@ public class MonitoredActivity extends AppCompatActivity {
         private final ForegroundJob<T> mJob;
 
         private final Runnable mCleanupRunner = new Runnable() {
+            @Override
             public void run() {
                 removeLifeCycleListener(Job.this);
                 if (mDialog.getWindow() != null) {

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/processor/MediaProcessor.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/processor/MediaProcessor.java
@@ -119,6 +119,7 @@ public abstract class MediaProcessor implements Runnable {
             URL url = new URL(sourceFile);
             final HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
             in = new BufferedInputStream(urlConnection.getInputStream()) {
+                @Override
                 public void close() throws IOException {
                     super.close();
                     urlConnection.disconnect();

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/BitmapManager.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/BitmapManager.java
@@ -77,6 +77,7 @@ public class BitmapManager {
             mWeakCollection.remove(t);
         }
 
+        @Override
         public Iterator<Thread> iterator() {
 
             return mWeakCollection.keySet().iterator();

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/CropImageActivity.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/CropImageActivity.java
@@ -247,6 +247,7 @@ public class CropImageActivity extends MonitoredActivity {
         mImageView.setImageBitmapResetBase(mBitmap, true);
 
         startBackgroundJob(R.string.rte_processing_image, new Runnable() {
+            @Override
             public void run() {
                 final Bitmap b = mBitmap;
                 if (b != mBitmap && b != null) {
@@ -370,6 +371,7 @@ public class CropImageActivity extends MonitoredActivity {
         } else {
             final Bitmap b = croppedImage;
             startBackgroundJob(R.string.rte_processing_image, new Runnable() {
+                @Override
                 public void run() {
                     saveOutput(b);
                 }
@@ -536,6 +538,7 @@ public class CropImageActivity extends MonitoredActivity {
                     mBitmap.getHeight(), matrix, true);
         }
 
+        @Override
         public void run() {
 
             mImageMatrix = mImageView.getImageMatrix();
@@ -553,6 +556,7 @@ public class CropImageActivity extends MonitoredActivity {
             }
 
             mHandler.post(new Runnable() {
+                @Override
                 public void run() {
                     mWaitingToPick = mNumFaces > 1;
                     if (mNumFaces > 0) {

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/ImageViewTouchBase.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/ImageViewTouchBase.java
@@ -153,6 +153,7 @@ abstract class ImageViewTouchBase extends ImageView {
 
         if (viewWidth <= 0) {
             mOnLayoutRunnable = new Runnable() {
+                @Override
                 public void run() {
 
                     setImageRotateBitmapResetBase(bitmap, resetSupp);
@@ -319,6 +320,7 @@ abstract class ImageViewTouchBase extends ImageView {
         final long startTime = System.currentTimeMillis();
 
         mHandler.post(new Runnable() {
+            @Override
             public void run() {
 
                 long now = System.currentTimeMillis();

--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/LineIterator.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/LineIterator.java
@@ -84,6 +84,7 @@ public class LineIterator implements Iterator<String> {
      * @return {@code true} if the Reader has more lines
      * @throws IllegalStateException if an IO exception occurs
      */
+    @Override
     public boolean hasNext() {
         if (cachedLine != null) {
             return true;
@@ -124,6 +125,7 @@ public class LineIterator implements Iterator<String> {
      * @return the next line from the input
      * @throws NoSuchElementException if there is no line to return
      */
+    @Override
     public String next() {
         return nextLine();
     }
@@ -161,6 +163,7 @@ public class LineIterator implements Iterator<String> {
      *
      * @throws UnsupportedOperationException always
      */
+    @Override
     public void remove() {
         throw new UnsupportedOperationException("Remove unsupported on LineIterator");
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - “ "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.
Ayman Abdelghany.
