### PR TITLE
[squid:S1168] Empty arrays and collections should be returned instead of null

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/validator/InetAddressValidator.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/validator/InetAddressValidator.java
@@ -75,7 +75,7 @@ public class InetAddressValidator implements Serializable {
         // verify that address conforms to generic IPv4 format
         String[] groups = ipv4Validator.match(inet4Address);
 
-        if (groups == null) {
+        if (groups.length == 0) {
             return false;
         }
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/validator/RegexValidator.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/validator/RegexValidator.java
@@ -158,7 +158,7 @@ public class RegexValidator implements Serializable {
      */
     public String[] match(String value) {
         if (value == null) {
-            return null;
+            return new String[0];
         }
         for (int i = 0; i < patterns.length; i++) {
             Matcher matcher = patterns[i].matcher(value);
@@ -171,7 +171,7 @@ public class RegexValidator implements Serializable {
                 return groups;
             }
         }
-        return null;
+        return new String[0];
     }
 
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1168 - “Empty arrays and collections should be returned instead of null”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1168

Please let me know if you have any questions.
Ayman Abdelghany.
