### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/util/StringEscapeUtils.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/util/StringEscapeUtils.java
@@ -62,6 +62,12 @@ public class StringEscapeUtils {
             );
 
     /**
+     * Prevents class instantiation.
+     */
+    private StringEscapeUtils() {
+    }
+
+    /**
      * <p>Escapes the characters in a {@code String} using HTML entities.</p>
      * <p/>
      * <p>

--- a/RTEditor/src/main/java/com/onegravity/rteditor/fonts/FontManager.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/fonts/FontManager.java
@@ -68,6 +68,12 @@ public class FontManager {
     };
 
     /**
+     * Prevents class instantiation.
+     */
+    private FontManager() {
+    }
+
+    /**
      * Use this method to preload fonts asynchronously e.g. when the app starts up.
      */
     public static void preLoadFonts(final Context context) {

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/MediaUtils.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/MediaUtils.java
@@ -33,6 +33,12 @@ import com.onegravity.rteditor.utils.Helper;
  * Collection of utility functions used in the media package
  */
 public class MediaUtils {
+    
+    /**
+     * Prevents class instantiation.
+     */
+    private MediaUtils() {
+    }
 
     /**
      * Creates a file with a non-conflicting file name in a specified folder based on an existing file name.

--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/FilenameUtils.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/FilenameUtils.java
@@ -122,9 +122,9 @@ public class FilenameUtils {
     }
 
     /**
-     * Instances should NOT be constructed in standard programming.
+     * Prevents class instantiation.
      */
-    public FilenameUtils() {
+    private FilenameUtils() {
         super();
     }
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/IOUtils.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/IOUtils.java
@@ -147,9 +147,9 @@ public class IOUtils {
     private static byte[] SKIP_BYTE_BUFFER;
 
     /**
-     * Instances should NOT be constructed in standard programming.
+     * Prevents class instantiation.
      */
-    public IOUtils() {
+    private IOUtils() {
         super();
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
