### PR TITLE
[squid:S1596]  Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/validator/UrlValidator.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/validator/UrlValidator.java
@@ -257,7 +257,7 @@ public class UrlValidator implements Serializable {
         this.options = options;
 
         if (isOn(ALLOW_ALL_SCHEMES)) {
-            allowedSchemes = Collections.EMPTY_SET;
+            allowedSchemes = Collections.emptySet();
         } else {
             if (schemes == null) {
                 schemes = DEFAULT_SCHEMES;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1596 - “Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1596

Please let me know if you have any questions.
Ayman Abdelghany.
