### PR TITLE
[squid:S1905] Redundant casts should not be used

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLWriter.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLWriter.java
@@ -471,7 +471,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
      * @see #setPrefix
      */
     public String getPrefix(String uri) {
-        return (String) prefixTable.get(uri);
+        return prefixTable.get(uri);
     }
 
     /**
@@ -781,7 +781,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
     private void forceNSDecls() {
         Enumeration<String> prefixes = forcedDeclTable.keys();
         while (prefixes.hasMoreElements()) {
-            String prefix = (String) prefixes.nextElement();
+            String prefix = prefixes.nextElement();
             doPrefix(prefix, null, true);
         }
     }
@@ -812,14 +812,14 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
         if (prefix != null) {
             return prefix;
         }
-        prefix = (String) doneDeclTable.get(uri);
+        prefix = doneDeclTable.get(uri);
         if (prefix != null
                 && ((!isElement || defaultNS != null) && "".equals(prefix) || nsSupport
                 .getURI(prefix) != null)) {
             prefix = null;
         }
         if (prefix == null) {
-            prefix = (String) prefixTable.get(uri);
+            prefix = prefixTable.get(uri);
             if (prefix != null
                     && ((!isElement || defaultNS != null) && "".equals(prefix) || nsSupport
                     .getURI(prefix) != null)) {
@@ -949,7 +949,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
     private void writeNSDecls() throws SAXException {
         Enumeration<String> prefixes = (Enumeration<String>) nsSupport.getDeclaredPrefixes();
         while (prefixes.hasMoreElements()) {
-            String prefix = (String) prefixes.nextElement();
+            String prefix = prefixes.nextElement();
             String uri = nsSupport.getURI(prefix);
             if (uri == null) {
                 uri = "";

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
@@ -298,7 +298,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
 
     @Override
     public boolean getFeature(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
-        Boolean b = (Boolean) theFeatures.get(name);
+        Boolean b = theFeatures.get(name);
         if (b == null) {
             throw new SAXNotRecognizedException("Unknown feature " + name);
         }
@@ -307,7 +307,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
 
     @Override
     public void setFeature(String name, boolean value) throws SAXNotRecognizedException, SAXNotSupportedException {
-        Boolean b = (Boolean) theFeatures.get(name);
+        Boolean b = theFeatures.get(name);
         if (b == null) {
             throw new SAXNotRecognizedException("Unknown feature " + name);
         }
@@ -920,7 +920,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
                 lastc = c;
             }
             l.add(val.substring(s, e));
-            return (String[]) l.toArray(new String[0]);
+            return l.toArray(new String[0]);
         }
     }
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Schema.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Schema.java
@@ -126,7 +126,7 @@ public abstract class Schema {
 
     @SuppressLint("DefaultLocale")
     public ElementType getElementType(String name) {
-        return (ElementType) (theElementTypes.get(name.toLowerCase()));
+        return theElementTypes.get(name.toLowerCase());
     }
 
     /**
@@ -138,7 +138,7 @@ public abstract class Schema {
 
     public int getEntity(String name) {
         // System.err.println("%% Looking up entity " + name);
-        Integer ch = (Integer) theEntities.get(name);
+        Integer ch = theEntities.get(name);
         if (ch == null)
             return 0;
         return ch.intValue();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1905 - “Redundant casts should not be used”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1905

Please let me know if you have any questions.
Ayman Abdelghany.
