### PR TITLE
[squid:S1197] Array designators "[]" should be on the type, not the variable

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/ConverterHtmlToSpanned.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/ConverterHtmlToSpanned.java
@@ -195,7 +195,7 @@ public class ConverterHtmlToSpanned implements ContentHandler {
     }
 
     @Override
-    public void characters(char ch[], int start, int length) throws SAXException {
+    public void characters(char[] ch, int start, int length) throws SAXException {
         if (mIgnoreContent) return;
 
         StringBuilder sb = new StringBuilder();
@@ -234,7 +234,7 @@ public class ConverterHtmlToSpanned implements ContentHandler {
     }
 
     @Override
-    public void ignorableWhitespace(char ch[], int start, int length) throws SAXException {
+    public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
     }
 
     @Override

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLWriter.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/HTMLWriter.java
@@ -706,7 +706,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
      * @see org.xml.sax.ContentHandler#characters
      */
     @Override
-    public void characters(char ch[], int start, int len) throws SAXException {
+    public void characters(char[] ch, int start, int len) throws SAXException {
         if (!cdataElement) {
             if (mIgnoreChars) {
                 writeText4Links();
@@ -737,7 +737,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
      * @see org.xml.sax.ContentHandler#ignorableWhitespace
      */
     @Override
-    public void ignorableWhitespace(char ch[], int start, int length) throws SAXException {
+    public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
         writeText4Links();
         writeEscUTF16(new String(ch), start, length, false);
         super.ignorableWhitespace(ch, start, length);
@@ -1104,7 +1104,7 @@ public class HTMLWriter extends XMLFilterImpl implements LexicalHandler {
 
     private StringBuffer mLastText4Links = new StringBuffer();
 
-    private void collectText4Links(char ch[], int start, int len) throws SAXException {
+    private void collectText4Links(char[] ch, int start, int len) throws SAXException {
         mLastText4Links.append(String.valueOf(ch, start, len));
     }
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/output/ByteArrayOutputStream.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/output/ByteArrayOutputStream.java
@@ -319,7 +319,7 @@ public class ByteArrayOutputStream extends OutputStream {
         if (remaining == 0) {
             return EMPTY_BYTE_ARRAY; 
         }
-        byte newbuf[] = new byte[remaining];
+        byte[] newbuf = new byte[remaining];
         int pos = 0;
         for (byte[] buf : buffers) {
             int c = Math.min(buf.length, remaining);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - “Array designators "[]" should be on the type, not the variable”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.
Ayman Abdelghany.
