### PR TITLE
[squid:RedundantThrowsDeclarationCheck] Throws declarations should not be superfluous

### DIFF
--- a/RTEditor-Base/ColorPicker/src/main/java/com/larswerkman/holocolorpicker/Util.java
+++ b/RTEditor-Base/ColorPicker/src/main/java/com/larswerkman/holocolorpicker/Util.java
@@ -78,7 +78,7 @@ public class Util {
      *
      * @throws NumberFormatException
      */
-    public static int convertToColorInt(String a, String r, String g, String b, boolean useAlpha) throws NumberFormatException {
+    public static int convertToColorInt(String a, String r, String g, String b, boolean useAlpha) {
         int alpha = useAlpha ? Integer.parseInt(a, 16) : 0xff;
         int red = Integer.parseInt(r, 16);
         int green = Integer.parseInt(g, 16);

--- a/RTEditor-Base/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/AttributesImpl.java
+++ b/RTEditor-Base/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/AttributesImpl.java
@@ -556,7 +556,7 @@ public class AttributesImpl implements Attributes {
      * @param index The index to report.
      * @throws java.lang.ArrayIndexOutOfBoundsException Always.
      */
-    private void badIndex(int index) throws ArrayIndexOutOfBoundsException {
+    private void badIndex(int index) {
         String msg = "Attempt to modify attribute at illegal index: " + index;
         throw new ArrayIndexOutOfBoundsException(msg);
     }

--- a/RTEditor-Base/RTEditor/src/main/java/com/onegravity/rteditor/media/MediaUtils.java
+++ b/RTEditor-Base/RTEditor/src/main/java/com/onegravity/rteditor/media/MediaUtils.java
@@ -90,7 +90,7 @@ public class MediaUtils {
      * @throws IllegalArgumentException If the uri is null or we can't resolve the uri to an absolute file path
      *                                  (meaning the uri isn't valid)
      */
-    public static String determineOriginalFile(Context context, Uri uri) throws IllegalArgumentException {
+    public static String determineOriginalFile(Context context, Uri uri) {
         String originalFile = null;
 
         if (uri != null) {

--- a/RTEditor-Base/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/LineIterator.java
+++ b/RTEditor-Base/RTEditor/src/main/java/com/onegravity/rteditor/utils/io/LineIterator.java
@@ -64,7 +64,7 @@ public class LineIterator implements Iterator<String> {
      * @param reader the <code>Reader</code> to read from, not null
      * @throws IllegalArgumentException if the reader is null
      */
-    public LineIterator(final Reader reader) throws IllegalArgumentException {
+    public LineIterator(final Reader reader) {
         if (reader == null) {
             throw new IllegalArgumentException("Reader must not be null");
         }

--- a/RTEditor-Base/RTEditor/src/main/java/com/onegravity/rteditor/utils/validator/DomainValidator.java
+++ b/RTEditor-Base/RTEditor/src/main/java/com/onegravity/rteditor/utils/validator/DomainValidator.java
@@ -1112,7 +1112,7 @@ public class DomainValidator implements Serializable {
      * Allows code to be compiled with Java 1.4 and 1.5 
      * @throws IllegalArgumentException if the input string doesn't conform to RFC 3490 specification
      */
-    private static final String toASCII(String line) throws IllegalArgumentException {
+    private static final String toASCII(String line) {
 //        java.net.IDN.toASCII(line); // Java 1.6+
         // implementation for Java 1.4 and 1.5
         // effectively this is done by IDN.toASCII but we want to skip the entire call

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
@@ -886,7 +886,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
 
     // Split the supplied String into words or phrases seperated by spaces.
     // Recognises quotes around a phrase and doesn't split it.
-    private static String[] split(String val) throws IllegalArgumentException {
+    private static String[] split(String val) {
         val = val.trim();
         if (val.length() == 0) {
             return new String[0];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:RedundantThrowsDeclarationCheck - “Throws declarations should not be superfluous”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck

Please let me know if you have any questions.
Ayman Abdelghany.
