### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the correct order

### DIFF
--- a/RTEditor-Toolbar/src/main/java/com/onegravity/rteditor/toolbar/spinner/FontSizeSpinnerItem.java
+++ b/RTEditor-Toolbar/src/main/java/com/onegravity/rteditor/toolbar/spinner/FontSizeSpinnerItem.java
@@ -22,7 +22,7 @@ import android.widget.TextView;
  * The spinner item for the font size.
  */
 public class FontSizeSpinnerItem extends SpinnerItem {
-    final private int mFontSize;
+    private final int mFontSize;
     private final boolean mIsEmpty;
 
     public FontSizeSpinnerItem(int size, String title, boolean isEmpty) {

--- a/RTEditor-Toolbar/src/main/java/com/onegravity/rteditor/toolbar/spinner/FontSpinnerItem.java
+++ b/RTEditor-Toolbar/src/main/java/com/onegravity/rteditor/toolbar/spinner/FontSpinnerItem.java
@@ -22,7 +22,7 @@ import com.onegravity.rteditor.fonts.RTTypeface;
  * The spinner item for the font.
  */
 public class FontSpinnerItem extends SpinnerItem {
-    final private RTTypeface mTypeface;
+    private final RTTypeface mTypeface;
 
     public FontSpinnerItem(RTTypeface typeface) {
         super(typeface == null ? "" : typeface.getName());

--- a/RTEditor-Toolbar/src/main/java/com/onegravity/rteditor/toolbar/spinner/SpinnerItem.java
+++ b/RTEditor-Toolbar/src/main/java/com/onegravity/rteditor/toolbar/spinner/SpinnerItem.java
@@ -24,7 +24,7 @@ import android.widget.TextView;
  * The base class for the color and font spinners.
  */
 public abstract class SpinnerItem {
-    final protected String mTitle;
+    protected final String mTitle;
 
     protected OnChangedListener mOnChangedListener;
     protected Object mListenerTag;

--- a/RTEditor-Toolbar/src/main/java/com/onegravity/rteditor/toolbar/spinner/SpinnerItemAdapter.java
+++ b/RTEditor-Toolbar/src/main/java/com/onegravity/rteditor/toolbar/spinner/SpinnerItemAdapter.java
@@ -40,8 +40,8 @@ import java.util.List;
  */
 public class SpinnerItemAdapter<T extends SpinnerItem> extends BaseAdapter implements SpinnerItem.OnChangedListener {
 
-    final private int mSpinnerId;
-    final private int mSpinnerItemId;
+    private final int mSpinnerId;
+    private final int mSpinnerItemId;
 
     private int mSelectedItem;
     private List<T> mItems;
@@ -54,7 +54,7 @@ public class SpinnerItemAdapter<T extends SpinnerItem> extends BaseAdapter imple
 
     private Handler mHandler;
 
-    final private SparseArray<View> mViewCache = new SparseArray<>();
+    private final SparseArray<View> mViewCache = new SparseArray<>();
 
     private int mSelectedBackgroundId;
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/LinkFragment.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/LinkFragment.java
@@ -52,8 +52,8 @@ public class LinkFragment extends DialogFragment {
      * The Link class describes a link (link text and an URL).
      */
     static class Link {
-        final private String mLinkText;
-        final private String mUrl;
+        private final String mLinkText;
+        private final String mUrl;
 
         private Link(String linkText, String url) {
             mLinkText = linkText;

--- a/RTEditor/src/main/java/com/onegravity/rteditor/RTEditText.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/RTEditText.java
@@ -476,7 +476,7 @@ public class RTEditText extends EditText implements TextWatcher, SpanWatcher, Li
         }
     }
 
-    synchronized private void setParagraphsAreUp2Date(boolean value) {
+    private synchronized void setParagraphsAreUp2Date(boolean value) {
         if (! mIgnoreParagraphChanges) {
             mParagraphsAreUp2Date = value;
         }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/RTManager.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/RTManager.java
@@ -140,30 +140,30 @@ public class RTManager implements RTToolbarListener, RTEditTextListener {
     /*
      * We need these to delay hiding the toolbar after a focus loss of an editor
      */
-    transient private Handler mHandler;
-    transient private boolean mIsPendingFocusLoss;
-    transient private boolean mCancelPendingFocusLoss;
+    private transient Handler mHandler;
+    private transient boolean mIsPendingFocusLoss;
+    private transient boolean mCancelPendingFocusLoss;
 
     /*
      * Map the registered editors by editor id (RTEditText.getId())
      */
-    transient private Map<Integer, RTEditText> mEditors;
+    private transient Map<Integer, RTEditText> mEditors;
 
     /*
      * Map the registered toolbars by toolbar id (RTToolbar.getId())
      */
-    transient private Map<Integer, RTToolbar> mToolbars;
+    private transient Map<Integer, RTToolbar> mToolbars;
 
     /*
      * That's our link to "the outside world" to perform operations that need
      * access to a Context or an Activity
      */
-    transient private RTApi mRTApi;
+    private transient RTApi mRTApi;
 
     /*
      * The RTOperationManager is used to undo/redo operations
      */
-    transient private RTOperationManager mOPManager;
+    private transient RTOperationManager mOPManager;
 
     // ****************************************** Lifecycle Methods *******************************************
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/api/RTApi.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/api/RTApi.java
@@ -96,8 +96,8 @@ public class RTApi implements RTProxy, RTMediaFactory<RTImage, RTAudio, RTVideo>
 	 * Constructor
 	 */
 
-    transient final private RTProxy mRTProxy;    // not Serializable
-    final private RTMediaFactory<RTImage, RTAudio, RTVideo> mMediaFactory;
+    private final transient RTProxy mRTProxy;    // not Serializable
+    private final RTMediaFactory<RTImage, RTAudio, RTVideo> mMediaFactory;
 
     /**
      * @param context      Can be an Application or an Activity context

--- a/RTEditor/src/main/java/com/onegravity/rteditor/api/RTProxyImpl.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/api/RTProxyImpl.java
@@ -36,7 +36,7 @@ import java.lang.ref.SoftReference;
  */
 public class RTProxyImpl implements RTProxy {
 
-    final private SoftReference<Activity> mActivity;
+    private final SoftReference<Activity> mActivity;
 
     public RTProxyImpl(Activity activity) {
         mActivity = new SoftReference<>(activity);

--- a/RTEditor/src/main/java/com/onegravity/rteditor/api/format/RTText.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/api/format/RTText.java
@@ -31,8 +31,8 @@ import com.onegravity.rteditor.api.media.RTVideo;
  */
 public abstract class RTText {
 
-    final private RTFormat mRTFormat;
-    final private CharSequence mRTText;
+    private final RTFormat mRTFormat;
+    private final CharSequence mRTText;
 
     /**
      * Use this constructor if the class supports exactly one rich text format

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/AccumulatedParagraphStyle.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/AccumulatedParagraphStyle.java
@@ -21,7 +21,7 @@ package com.onegravity.rteditor.converter;
  * It's the accumulated paragraph styles (all SingleParagraphStyle of a paragraph together)
  */
 public class AccumulatedParagraphStyle {
-	final private ParagraphType mType;
+	private final ParagraphType mType;
 	private int mAbsoluteIndent;
 	private int mRelativeIndent;
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/ParagraphType.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/ParagraphType.java
@@ -50,12 +50,12 @@ public enum ParagraphType {
         }
     }
 
-    final private String mStartTag;
-    final private String mEndTag;
-    final private boolean mIsAlignment;
-    final private String mListStartTag;
-    final private String mListEndTag;
-    final private boolean mEndTagAddsLineBreak;
+    private final String mStartTag;
+    private final String mEndTag;
+    private final boolean mIsAlignment;
+    private final String mListStartTag;
+    private final String mListEndTag;
+    private final boolean mEndTagAddsLineBreak;
 
     private ParagraphType(String startTag, String endTag, String listStartTag,
                           String listEndTag, boolean isAlignment, boolean endTagAddsLineBreak) {

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/SingleParagraphStyle.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/SingleParagraphStyle.java
@@ -26,8 +26,8 @@ import com.onegravity.rteditor.utils.Helper;
  * It's the paragraph style for a single line.
  */
 public class SingleParagraphStyle implements ParagraphStyle {
-    final private ParagraphType mType;
-    final private ParagraphStyle mStyle;
+    private final ParagraphType mType;
+    private final ParagraphStyle mStyle;
 
     public SingleParagraphStyle(ParagraphType type, ParagraphStyle style) {
         mType = type;

--- a/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/converter/tagsoup/Parser.java
@@ -86,26 +86,26 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
      * A value of "true" indicates namespace URIs and unprefixed local names for
      * element and attribute names will be available.
      */
-    public final static String namespacesFeature = "http://xml.org/sax/features/namespaces";
+    public static final String namespacesFeature = "http://xml.org/sax/features/namespaces";
 
     /**
      * A value of "true" indicates that XML qualified names (with prefixes) and
      * attributes (including xmlns* attributes) will be available. We don't
      * support this value.
      */
-    public final static String namespacePrefixesFeature = "http://xml.org/sax/features/namespace-prefixes";
+    public static final String namespacePrefixesFeature = "http://xml.org/sax/features/namespace-prefixes";
 
     /**
      * Reports whether this parser processes external general entities (it
      * doesn't).
      */
-    public final static String externalGeneralEntitiesFeature = "http://xml.org/sax/features/external-general-entities";
+    public static final String externalGeneralEntitiesFeature = "http://xml.org/sax/features/external-general-entities";
 
     /**
      * Reports whether this parser processes external parameter entities (it
      * doesn't).
      */
-    public final static String externalParameterEntitiesFeature = "http://xml.org/sax/features/external-parameter-entities";
+    public static final String externalParameterEntitiesFeature = "http://xml.org/sax/features/external-parameter-entities";
 
     /**
      * May be examined only during a parse, after the startDocument() callback
@@ -113,20 +113,20 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
      * specified standalone="yes" in its XML declaration, and otherwise is
      * false. (It's always false.)
      */
-    public final static String isStandaloneFeature = "http://xml.org/sax/features/is-standalone";
+    public static final String isStandaloneFeature = "http://xml.org/sax/features/is-standalone";
 
     /**
      * A value of "true" indicates that the LexicalHandler will report the
      * beginning and end of parameter entities (it won't).
      */
-    public final static String lexicalHandlerParameterEntitiesFeature = "http://xml.org/sax/features/lexical-handler/parameter-entities";
+    public static final String lexicalHandlerParameterEntitiesFeature = "http://xml.org/sax/features/lexical-handler/parameter-entities";
 
     /**
      * A value of "true" indicates that system IDs in declarations will be
      * absolutized (relative to their base URIs) before reporting. (This returns
      * true but doesn't actually do anything.)
      */
-    public final static String resolveDTDURIsFeature = "http://xml.org/sax/features/resolve-dtd-uris";
+    public static final String resolveDTDURIsFeature = "http://xml.org/sax/features/resolve-dtd-uris";
 
     /**
      * Has a value of "true" if all XML names (for elements, prefixes,
@@ -135,7 +135,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
      * supports fast testing of equality/inequality against string constants,
      * rather than forcing slower calls to String.equals(). (We always intern.)
      */
-    public final static String stringInterningFeature = "http://xml.org/sax/features/string-interning";
+    public static final String stringInterningFeature = "http://xml.org/sax/features/string-interning";
 
     /**
      * Returns "true" if the Attributes objects passed by this parser in
@@ -143,82 +143,82 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
      * interface. (They don't.)
      */
 
-    public final static String useAttributes2Feature = "http://xml.org/sax/features/use-attributes2";
+    public static final String useAttributes2Feature = "http://xml.org/sax/features/use-attributes2";
 
     /**
      * Returns "true" if the Locator objects passed by this parser in
      * ContentHandler.setDocumentLocator() implement the
      * org.xml.sax.ext.Locator2 interface. (They don't.)
      */
-    public final static String useLocator2Feature = "http://xml.org/sax/features/use-locator2";
+    public static final String useLocator2Feature = "http://xml.org/sax/features/use-locator2";
 
     /**
      * Returns "true" if, when setEntityResolver is given an object implementing
      * the org.xml.sax.ext.EntityResolver2 interface, those new methods will be
      * used. (They won't be.)
      */
-    public final static String useEntityResolver2Feature = "http://xml.org/sax/features/use-entity-resolver2";
+    public static final String useEntityResolver2Feature = "http://xml.org/sax/features/use-entity-resolver2";
 
     /**
      * Controls whether the parser is reporting all validity errors (We don't
      * report any validity errors.)
      */
-    public final static String validationFeature = "http://xml.org/sax/features/validation";
+    public static final String validationFeature = "http://xml.org/sax/features/validation";
 
     /**
      * Controls whether the parser reports Unicode normalization errors as
      * described in section 2.13 and Appendix B of the XML 1.1 Recommendation.
      * (We don't normalize.)
      */
-    public final static String unicodeNormalizationCheckingFeature = "http://xml.org/sax/features/unicode-normalization-checking";
+    public static final String unicodeNormalizationCheckingFeature = "http://xml.org/sax/features/unicode-normalization-checking";
 
     /**
      * Controls whether, when the namespace-prefixes feature is set, the parser
      * treats namespace declaration attributes as being in the
      * http://www.w3.org/2000/xmlns/ namespace. (It doesn't.)
      */
-    public final static String xmlnsURIsFeature = "http://xml.org/sax/features/xmlns-uris";
+    public static final String xmlnsURIsFeature = "http://xml.org/sax/features/xmlns-uris";
 
     /**
      * Returns "true" if the parser supports both XML 1.1 and XML 1.0. (Always
      * false.)
      */
-    public final static String XML11Feature = "http://xml.org/sax/features/xml-1.1";
+    public static final String XML11Feature = "http://xml.org/sax/features/xml-1.1";
 
     /**
      * A value of "true" indicates that the parser will ignore unknown elements.
      */
-    public final static String ignoreBogonsFeature = "http://www.ccil.org/~cowan/tagsoup/features/ignore-bogons";
+    public static final String ignoreBogonsFeature = "http://www.ccil.org/~cowan/tagsoup/features/ignore-bogons";
 
     /**
      * A value of "true" indicates that the parser will give unknown elements a
      * content model of EMPTY; a value of "false", a content model of ANY.
      */
-    public final static String bogonsEmptyFeature = "http://www.ccil.org/~cowan/tagsoup/features/bogons-empty";
+    public static final String bogonsEmptyFeature = "http://www.ccil.org/~cowan/tagsoup/features/bogons-empty";
 
     /**
      * A value of "true" indicates that the parser will allow unknown elements
      * to be the root element.
      */
-    public final static String rootBogonsFeature = "http://www.ccil.org/~cowan/tagsoup/features/root-bogons";
+    public static final String rootBogonsFeature = "http://www.ccil.org/~cowan/tagsoup/features/root-bogons";
 
     /**
      * A value of "true" indicates that the parser will return default attribute
      * values for missing attributes that have default values.
      */
-    public final static String defaultAttributesFeature = "http://www.ccil.org/~cowan/tagsoup/features/default-attributes";
+    public static final String defaultAttributesFeature = "http://www.ccil.org/~cowan/tagsoup/features/default-attributes";
 
     /**
      * A value of "true" indicates that the parser will translate colons into
      * underscores in names.
      */
-    public final static String translateColonsFeature = "http://www.ccil.org/~cowan/tagsoup/features/translate-colons";
+    public static final String translateColonsFeature = "http://www.ccil.org/~cowan/tagsoup/features/translate-colons";
 
     /**
      * A value of "true" indicates that the parser will attempt to restart the
      * restartable elements.
      */
-    public final static String restartElementsFeature = "http://www.ccil.org/~cowan/tagsoup/features/restart-elements";
+    public static final String restartElementsFeature = "http://www.ccil.org/~cowan/tagsoup/features/restart-elements";
 
     /**
      * A value of "true" indicates that the parser will transmit whitespace in
@@ -226,13 +226,13 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
      * this is not done, because HTML is an SGML application and SGML suppresses
      * such whitespace.
      */
-    public final static String ignorableWhitespaceFeature = "http://www.ccil.org/~cowan/tagsoup/features/ignorable-whitespace";
+    public static final String ignorableWhitespaceFeature = "http://www.ccil.org/~cowan/tagsoup/features/ignorable-whitespace";
 
     /**
      * A value of "true" indicates that the parser will treat CDATA elements
      * specially. Normally true, since the input is by default HTML.
      */
-    public final static String CDATAElementsFeature = "http://www.ccil.org/~cowan/tagsoup/features/cdata-elements";
+    public static final String CDATAElementsFeature = "http://www.ccil.org/~cowan/tagsoup/features/cdata-elements";
 
     /**
      * Used to see some syntax events that are essential in some applications:
@@ -240,22 +240,22 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
      * start and end of the DTD (and declaration of document element name). The
      * Object must implement org.xml.sax.ext.LexicalHandler.
      */
-    public final static String lexicalHandlerProperty = "http://xml.org/sax/properties/lexical-handler";
+    public static final String lexicalHandlerProperty = "http://xml.org/sax/properties/lexical-handler";
 
     /**
      * Specifies the Scanner object this Parser uses.
      */
-    public final static String scannerProperty = "http://www.ccil.org/~cowan/tagsoup/properties/scanner";
+    public static final String scannerProperty = "http://www.ccil.org/~cowan/tagsoup/properties/scanner";
 
     /**
      * Specifies the Schema object this Parser uses.
      */
-    public final static String schemaProperty = "http://www.ccil.org/~cowan/tagsoup/properties/schema";
+    public static final String schemaProperty = "http://www.ccil.org/~cowan/tagsoup/properties/schema";
 
     /**
      * Specifies the AutoDetector (for encoding detection) this Parser uses.
      */
-    public final static String autoDetectorProperty = "http://www.ccil.org/~cowan/tagsoup/properties/auto-detector";
+    public static final String autoDetectorProperty = "http://www.ccil.org/~cowan/tagsoup/properties/auto-detector";
 
     // Due to sucky Java order of initialization issues, these
     // entries are maintained separately from the initial values of

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/BooleanEffect.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/BooleanEffect.java
@@ -39,7 +39,7 @@ abstract class BooleanEffect<C extends RTSpan<Boolean>> extends CharacterEffect<
      * @return If the value is Null or False then return Null -> remove all spans.
      */
     @Override
-    final protected RTSpan<Boolean> newSpan(Boolean value) {
+    protected final RTSpan<Boolean> newSpan(Boolean value) {
         try {
             return value ? mSpanClazz.newInstance() : null;
         } catch (IllegalAccessException e) {

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/CharacterEffect.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/CharacterEffect.java
@@ -29,12 +29,12 @@ import com.onegravity.rteditor.utils.Selection;
 abstract class CharacterEffect<V, C extends RTSpan<V>> extends Effect<V, C> {
 
     @Override
-    final protected SpanCollector<V> newSpanCollector(Class<? extends RTSpan<V>> spanClazz) {
+    protected final SpanCollector<V> newSpanCollector(Class<? extends RTSpan<V>> spanClazz) {
         return new CharacterSpanCollector<>(spanClazz);
     }
 
     @Override
-    final protected Selection getSelection(RTEditText editor) {
+    protected final Selection getSelection(RTEditText editor) {
         return new Selection(editor);
     }
 
@@ -96,6 +96,6 @@ abstract class CharacterEffect<V, C extends RTSpan<V>> extends Effect<V, C> {
      * @return the class of the span this effect supports. Can be Null but then the subclass has to
      * override applyToSelection(RTEditText, V)
      */
-    abstract protected RTSpan<V> newSpan(V value);
+    protected abstract RTSpan<V> newSpan(V value);
 
 }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/CharacterSpanCollector.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/CharacterSpanCollector.java
@@ -32,7 +32,7 @@ class CharacterSpanCollector<V> extends SpanCollector<V> {
     }
 
     @Override
-    final protected List<RTSpan<V>> getSpans(Spannable str, Selection selection, SpanCollectMode mode) {
+    protected final List<RTSpan<V>> getSpans(Spannable str, Selection selection, SpanCollectMode mode) {
         List<RTSpan<V>> result = new ArrayList<>();
 
         /*

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/Effect.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/Effect.java
@@ -38,7 +38,7 @@ import java.util.List;
  *
  * @param <C> is the RTSpan<V> used by the Effect (e.g. BoldEffect uses BoldSpan)
  */
-abstract public class Effect<V, C extends RTSpan<V>> {
+public abstract class Effect<V, C extends RTSpan<V>> {
 
     private SpanCollector<V> mSpanCollector;
 
@@ -49,7 +49,7 @@ abstract public class Effect<V, C extends RTSpan<V>> {
      *
      * @return True if the effect exists in the current selection, False otherwise.
      */
-    final public boolean existsInSelection(RTEditText editor) {
+    public final boolean existsInSelection(RTEditText editor) {
         Selection selection = getSelection(editor);
         List<RTSpan<V>> spans = getSpans(editor.getText(), selection, SpanCollectMode.SPAN_FLAGS);
 
@@ -61,7 +61,7 @@ abstract public class Effect<V, C extends RTSpan<V>> {
      *
      * @return The returned list, must NEVER be null.
      */
-    final public List<V> valuesInSelection(RTEditText editor) {
+    public final List<V> valuesInSelection(RTEditText editor) {
         List<V> result = new ArrayList<>();
 
         Selection selection = getSelection(editor);
@@ -77,7 +77,7 @@ abstract public class Effect<V, C extends RTSpan<V>> {
      * Remove all effects of this type from the currently selected text of the active RTEditText.
      * If the selection is empty (cursor), formatting for the whole text is removed.
      */
-    final public void clearFormattingInSelection(RTEditText editor) {
+    public final void clearFormattingInSelection(RTEditText editor) {
         Spannable text = editor.getText();
 
         // if no selection --> select the whole text
@@ -102,7 +102,7 @@ abstract public class Effect<V, C extends RTSpan<V>> {
      *
      * @return the list of spans in this Spannable/Selection, never Null
      */
-    final public List<RTSpan<V>> getSpans(Spannable str, Selection selection, SpanCollectMode mode) {
+    public final List<RTSpan<V>> getSpans(Spannable str, Selection selection, SpanCollectMode mode) {
         if (mSpanCollector == null) {
             // lazy initialize the SpanCollector
             Type[] types = ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments();
@@ -116,12 +116,12 @@ abstract public class Effect<V, C extends RTSpan<V>> {
     /**
      * @return a new SpanCollector for this effect
      */
-    abstract protected SpanCollector<V> newSpanCollector(Class<? extends RTSpan<V>> spanClazz);
+    protected abstract SpanCollector<V> newSpanCollector(Class<? extends RTSpan<V>> spanClazz);
 
     /**
      * @return the Selection for the specified RTEditText.
      */
-    abstract protected Selection getSelection(RTEditText editor);
+    protected abstract Selection getSelection(RTEditText editor);
 
     /**
      * Apply this effect to the selection.
@@ -130,6 +130,6 @@ abstract public class Effect<V, C extends RTSpan<V>> {
      * @param editor The editor to apply the effect to (current selection)
      * @param value The value to apply (depends on the Effect)
      */
-    abstract public void applyToSelection(RTEditText editor, V value);
+    public abstract void applyToSelection(RTEditText editor, V value);
 
 }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/IntegerEffect.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/IntegerEffect.java
@@ -37,7 +37,7 @@ abstract class IntegerEffect<C extends RTSpan<Integer>> extends CharacterEffect<
     }
 
     @Override
-    final protected RTSpan<Integer> newSpan(Integer value) {
+    protected final RTSpan<Integer> newSpan(Integer value) {
         try {
             if (value != null) {
                 Class[] paramTypes = {int.class};

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/ParagraphEffect.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/ParagraphEffect.java
@@ -33,7 +33,7 @@ import java.util.List;
 abstract class ParagraphEffect<V, C extends RTSpan<V>> extends Effect<V, C> {
 
     @Override
-    final protected SpanCollector<V> newSpanCollector(Class<? extends RTSpan<V>> spanClazz) {
+    protected final SpanCollector<V> newSpanCollector(Class<? extends RTSpan<V>> spanClazz) {
         return new ParagraphSpanCollector<>(spanClazz);
     }
 
@@ -42,7 +42,7 @@ abstract class ParagraphEffect<V, C extends RTSpan<V>> extends Effect<V, C> {
      *         ParagraphEffects always operate on whole paragraphs.
      */
     @Override
-    final protected Selection getSelection(RTEditText editor) {
+    protected final Selection getSelection(RTEditText editor) {
         return editor.getParagraphsInSelection();
     }
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/ParagraphSpanCollector.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/ParagraphSpanCollector.java
@@ -32,7 +32,7 @@ class ParagraphSpanCollector<V> extends SpanCollector<V> {
     }
 
     @Override
-    final protected List<RTSpan<V>> getSpans(Spannable str, Selection selection, SpanCollectMode mode) {
+    protected final List<RTSpan<V>> getSpans(Spannable str, Selection selection, SpanCollectMode mode) {
         List<RTSpan<V>> result = new ArrayList<>();
 
         RTSpan<V>[] spans = getSpansAndroid(str, selection.start(), selection.end());

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/ParagraphSpanProcessor.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/ParagraphSpanProcessor.java
@@ -44,7 +44,7 @@ class ParagraphSpanProcessor<V extends Object> {
         }
     }
 
-    final private List<ParagraphSpan<V>> mParagraphSpans = new ArrayList<>();
+    private final List<ParagraphSpan<V>> mParagraphSpans = new ArrayList<>();
 
     void clear() {
         mParagraphSpans.clear();

--- a/RTEditor/src/main/java/com/onegravity/rteditor/effects/SpanCollector.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/effects/SpanCollector.java
@@ -80,7 +80,7 @@ abstract class SpanCollector<V> {
      * Return an array of the markup objects attached to the specified slice of a Spannable and whose
      * type is the specified type or a subclass of it (see Spanned.getSpans(int, int, Class<T>)).
      */
-    final protected RTSpan<V>[] getSpansAndroid(Spannable str, int selStart, int selEnd) {
+    protected final RTSpan<V>[] getSpansAndroid(Spannable str, int selStart, int selEnd) {
         RTSpan<V>[] spans = str.getSpans(selStart, selEnd, mSpanClazz);
         return spans == null ? (RTSpan<V>[]) Array.newInstance(mSpanClazz) : spans;
     }
@@ -88,7 +88,7 @@ abstract class SpanCollector<V> {
     /**
      * @return True if the flags contain at least one of the values, False otherwise.
      */
-    final protected boolean isOneFlagSet(int flags, int...value) {
+    protected final boolean isOneFlagSet(int flags, int...value) {
         for (int flag : value) {
             if ((flags & flag) == flag) {
                 return true;

--- a/RTEditor/src/main/java/com/onegravity/rteditor/fonts/TTFAssetInputStream.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/fonts/TTFAssetInputStream.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
  * This class is a TTFInputStream for AssetInputStream (used to read fonts from the assets folder).
  */
 public class TTFAssetInputStream implements TTFInputStream {
-    final private InputStream mIn;
+    private final InputStream mIn;
 
     TTFAssetInputStream(InputStream in) {
         mIn = in;

--- a/RTEditor/src/main/java/com/onegravity/rteditor/fonts/TTFRandomAccessFile.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/fonts/TTFRandomAccessFile.java
@@ -23,7 +23,7 @@ import java.io.RandomAccessFile;
  * This class is a TTFInputStream for RandomAccessFile (used to read system fonts).
  */
 public class TTFRandomAccessFile implements TTFInputStream {
-    final private RandomAccessFile mFile;
+    private final RandomAccessFile mFile;
 
     TTFRandomAccessFile(RandomAccessFile file) {
         mFile = file;

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/MediaChooserActivity.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/MediaChooserActivity.java
@@ -50,7 +50,7 @@ public class MediaChooserActivity extends MonitoredActivity implements
     private RTMediaFactory<RTImage, RTAudio, RTVideo> mMediaFactory;
     private MediaAction mMediaAction;
 
-    transient private MediaChooserManager mMediaChooserMgr;
+    private transient MediaChooserManager mMediaChooserMgr;
 
     private RTMedia mSelectedMedia;
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/MediaChooserManager.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/MediaChooserManager.java
@@ -41,13 +41,13 @@ abstract class MediaChooserManager implements MediaProcessorListener {
         public void onError(String reason);
     }
 
-    transient protected MonitoredActivity mActivity;
-    transient protected RTMediaFactory<RTImage, RTAudio, RTVideo> mMediaFactory;
+    protected transient MonitoredActivity mActivity;
+    protected transient RTMediaFactory<RTImage, RTAudio, RTVideo> mMediaFactory;
 
     // the type of chooser (see MediaChooserActivity.REQUEST_PICK_PICTURE etc.)
-    transient protected MediaAction mMediaAction;
+    protected transient MediaAction mMediaAction;
 
-    transient private MediaChooserListener mListener;
+    private transient MediaChooserListener mListener;
 
     // the file path and name of the original file
     // the MediaChooserManager sets this once the user picked a file

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/MediaEvent.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/MediaEvent.java
@@ -23,7 +23,7 @@ import com.onegravity.rteditor.api.media.RTMedia;
  * It's received by the RTManager to insert the media into the active editor.
  */
 public class MediaEvent {
-    final private RTMedia mMedia;
+    private final RTMedia mMedia;
 
     public MediaEvent(RTMedia selectedMedia) {
         mMedia = selectedMedia;

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/processor/MediaProcessor.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/choose/processor/MediaProcessor.java
@@ -44,9 +44,9 @@ public abstract class MediaProcessor implements Runnable {
         public void onError(String reason);
     }
 
-    final private MediaProcessorListener mListener;
+    private final MediaProcessorListener mListener;
 
-    final private String mOriginalFile;
+    private final String mOriginalFile;
 
     protected final RTMediaFactory<RTImage, RTAudio, RTVideo> mMediaFactory;
 
@@ -57,7 +57,7 @@ public abstract class MediaProcessor implements Runnable {
     }
 
     @Override
-    final public void run() {
+    public final void run() {
         try {
             processMedia();
         } catch (Exception e) {

--- a/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/ImageViewTouchBase.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/media/crop/ImageViewTouchBase.java
@@ -55,7 +55,7 @@ abstract class ImageViewTouchBase extends ImageView {
     private final float[] mMatrixValues = new float[9];
 
     // The current bitmap being displayed.
-    final protected RotateBitmap mBitmapDisplayed = new RotateBitmap(null);
+    protected final RotateBitmap mBitmapDisplayed = new RotateBitmap(null);
 
     int mThisWidth = -1, mThisHeight = -1;
 

--- a/RTEditor/src/main/java/com/onegravity/rteditor/spans/MediaSpan.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/spans/MediaSpan.java
@@ -27,11 +27,11 @@ import com.onegravity.rteditor.media.MediaUtils;
  */
 public abstract class MediaSpan extends android.text.style.ImageSpan {
 
-    final protected RTMedia mMedia;
+    protected final RTMedia mMedia;
 
     // when saving the text delete the Media if the MediaSpan was removed from the text
     // when dismissing the text delete the Media if the MediaSpan was removed from the text and if the Media wasn't saved
-    final private boolean mIsSaved;
+    private final boolean mIsSaved;
 
     public MediaSpan(RTMedia media, boolean isSaved) {
         super(RTApi.getApplicationContext(), MediaUtils.createFileUri(media.getFilePath(RTFormat.SPANNED)));

--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/Constants.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/Constants.java
@@ -41,6 +41,6 @@ public abstract class Constants {
         }
     }
 
-    public final static int CROP_IMAGE = 107;
+    public static final int CROP_IMAGE = 107;
 
 }

--- a/RTEditor/src/main/java/com/onegravity/rteditor/utils/Paragraph.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/utils/Paragraph.java
@@ -22,8 +22,8 @@ package com.onegravity.rteditor.utils;
 public class Paragraph extends Selection {
     private static final long serialVersionUID = 2475227150049924994L;
 
-    final private boolean mIsFirst;
-    final private boolean mIsLast;
+    private final boolean mIsFirst;
+    private final boolean mIsLast;
 
     public Paragraph(int start, int end, boolean isFirst, boolean isLast) {
         super(start, end);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Ayman Abdelghany.
